### PR TITLE
Refactor multifasta_reader for better file handling

### DIFF
--- a/aiupred/utils.py
+++ b/aiupred/utils.py
@@ -1,17 +1,28 @@
-def multifasta_reader(file_handler):
+from collections import defaultdict
+from pathlib import Path
+
+def multifasta_reader(fasta_path):
     """
     (multi) FASTA reader function
     :return: Dictionary with header -> sequence mapping from the file
     """
-    if type(file_handler) == str:
-        file_handler = open(file_handler)
-    sequence_dct = {}
+    try:
+        fasta = Path(fasta_path)
+        if not fasta.is_file()
+            raise ValueError(f"{fasta_path} is not a file")
+    except TypeError:
+        raise FileNotFoundError(f"Cannot create a valid file path from {fasta_path}")
+        
+    sequence_dct = defaultdict(str)
     header = None
-    for line in file_handler:
-        if line.startswith('>'):
-            header = line.strip()
-            sequence_dct[header] = ''
-        elif line.strip():
-            sequence_dct[header] += line.strip().upper()
-    file_handler.close()
-    return sequence_dct
+    with fasta.open("r") as file_handle:
+        for line in file_handle:
+            line = line.strip()
+            if line.startswith('>'):
+                header = line
+            elif line:
+                sequence_dct[header] += line.upper()
+
+    # convert to a regular dictionary before returning
+    # This prevents unforseen consequences when trying to retrieve sequences later
+    return dict(sequence_dct)


### PR DESCRIPTION
Refactor multifasta_reader to use Path for file handling and improve error handling. Use defaultdict instead of explicitly creating empty string for every new fasta sequence. Closes #10 